### PR TITLE
Update lda.js

### DIFF
--- a/lib/lda.js
+++ b/lib/lda.js
@@ -27,7 +27,7 @@ var process = function(sentences, numberOfTopics, numberOfTermsPerTopic, alphaVa
 		for(var wc=0;wc<words.length;wc++) {
 			var w=words[wc].toLowerCase().replace(/[^a-z\'A-Z0-9 ]+/g, '');
 			var wStemmed = stem(w);
-			if (w=="" || w.length==1 || stop_words.indexOf(w.replace("'", "")) > -1 || w.indexOf("http")==0) continue;
+			if (w=="" || !wStemmed || w.length==1 || stop_words.indexOf(w.replace("'", "")) > -1 || w.indexOf("http")==0) continue;
 			if (f[wStemmed]) { 
 				f[wStemmed]=f[wStemmed]+1;
 			} 


### PR DESCRIPTION
Fixing bug when word is not falsey, but is stemmed to falsey value "". In this situation the word will never be added to the vocab array on line 36, due to conditional on line 34, this pushes -1 into the documents 2d array, which will later cause an error in initialState on line 141 when accessing the -1th index in nw.

`
lda([":'\'s'"],1,1)
`
(Really unlikely to encounter this string outside of my own dataset, but it's possible it could affect other words)

Currently: throws error on line 141 due to accessing non-existant element of array
This code will produce correct result: [ [] ]
