### PR TITLE
Return the entire lda object

### DIFF
--- a/lib/lda.js
+++ b/lib/lda.js
@@ -5,8 +5,6 @@ var stem = require('stem-porter');
 // Original code based on http://www.arbylon.net/projects/LdaGibbsSampler.java
 //
 var process = function(sentences, numberOfTopics, numberOfTermsPerTopic, languages, alphaValue, betaValue) {
-    // The result will consist of topics and their included terms [[{"term":"word1", "probability":0.065}, {"term":"word2", "probability":0.047}, ... ], [{"term":"word1", "probability":0.085}, {"term":"word2", "probability":0.024}, ... ]].
-    var result = [];
     // Index-encoded array of sentences, with each row containing the indices of the words in the vocabulary.
     var documents = new Array();
     // Hash of vocabulary words and the count of how many times each word has been seen.
@@ -91,10 +89,10 @@ var process = function(sentences, numberOfTopics, numberOfTermsPerTopic, languag
             row.push(term);
         }
 
-        result.push(row);
+        lda.result.push(row);
     }
     
-    return result;
+    return lda;
 }
 
 function makeArray(x) {
@@ -116,6 +114,8 @@ function make2DArray(x,y) {
 }
 
 var lda = new function() {
+    // The result will consist of topics and their included terms [[{"term":"word1", "probability":0.065}, {"term":"word2", "probability":0.047}, ... ], [{"term":"word1", "probability":0.085}, {"term":"word2", "probability":0.024}, ... ]].
+    var result = [];
     var documents,z,nw,nd,nwsum,ndsum,thetasum,phisum,V,K,alpha,beta; 
     var THIN_INTERVAL = 20;
     var BURN_IN = 100;
@@ -132,6 +132,7 @@ var lda = new function() {
         this.V = v;
         this.dispcol=0;
         this.numstats=0; 
+        this.result = [];
     }
     this.initialState = function (K) {
         var i;


### PR DESCRIPTION
The results can still be accessed as following:
`var result = lda(documents, 2, 5).result;`

This change will allow me to use the `getTheta()` function of lda.
